### PR TITLE
.png and .rdp urls replaced with raw files content.

### DIFF
--- a/RdRemoteAppsParser/IRdWebClient.cs
+++ b/RdRemoteAppsParser/IRdWebClient.cs
@@ -4,7 +4,7 @@ using RdRemoteAppsParser.Models;
 namespace RdRemoteAppsParser
 {
     /// <summary>
-    ///     RemoteApps web client & parser class.
+    ///     RemoteApps web client 'n parser class.
     /// </summary>
     public interface IRdWebClient
     {

--- a/RdRemoteAppsParser/Models/AppModel.cs
+++ b/RdRemoteAppsParser/Models/AppModel.cs
@@ -10,22 +10,22 @@
         /// </summary>
         /// <param name="title">App name.</param>
         /// <param name="parentPath">App path without app name.</param>
-        /// <param name="rdpFileUrl">Url of .rdp file.</param>
-        /// <param name="pngPathUrl">Url of .png icon.</param>
-        public AppModel(string title, string parentPath, string rdpFileUrl, string pngPathUrl) : base(parentPath, title)
+        /// <param name="pngFileRaw">Raw png icon.</param>
+        /// <param name="rdpFileRaw">Raw .rdp file.</param>
+        public AppModel(string title, string parentPath, byte[] pngFileRaw, byte[] rdpFileRaw) : base(parentPath, title)
         {
-            PngPathUrl = pngPathUrl;
-            RdpFileUrl = rdpFileUrl;
+            PngFileRaw = pngFileRaw;
+            RdpFileRaw = rdpFileRaw;
         }
 
         /// <summary>
-        ///     Url of .png icon.
+        ///     Raw png icon.
         /// </summary>
-        public string PngPathUrl { get; set; }
+        public byte[] PngFileRaw { get; set; }
 
         /// <summary>
-        ///     Url of .rdp file.
+        ///     Raw .rdp file.
         /// </summary>
-        public string? RdpFileUrl { get; set; }
+        public byte[] RdpFileRaw { get; set; }
     }
 }

--- a/RdRemoteAppsParser/RdRemoteAppsParser.csproj
+++ b/RdRemoteAppsParser/RdRemoteAppsParser.csproj
@@ -12,6 +12,10 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <PackageReleaseNotes>.png and .rdp urls replaced with raw files content.</PackageReleaseNotes>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/RdRemoteAppsParser/RdRemoteAppsParser.xml
+++ b/RdRemoteAppsParser/RdRemoteAppsParser.xml
@@ -28,23 +28,23 @@
                 Single remote application data.
             </summary>
         </member>
-        <member name="M:RdRemoteAppsParser.Models.AppModel.#ctor(System.String,System.String,System.String,System.String)">
+        <member name="M:RdRemoteAppsParser.Models.AppModel.#ctor(System.String,System.String,System.Byte[],System.Byte[])">
             <summary>
                 Constructor.
             </summary>
             <param name="title">App name.</param>
             <param name="parentPath">App path without app name.</param>
-            <param name="rdpFileUrl">Url of .rdp file.</param>
-            <param name="pngPathUrl">Url of .png icon.</param>
+            <param name="pngFileRaw">Raw png icon.</param>
+            <param name="rdpFileRaw">Raw .rdp file.</param>
         </member>
-        <member name="P:RdRemoteAppsParser.Models.AppModel.PngPathUrl">
+        <member name="P:RdRemoteAppsParser.Models.AppModel.PngFileRaw">
             <summary>
-                Url of .png icon.
+                Raw png icon.
             </summary>
         </member>
-        <member name="P:RdRemoteAppsParser.Models.AppModel.RdpFileUrl">
+        <member name="P:RdRemoteAppsParser.Models.AppModel.RdpFileRaw">
             <summary>
-                Url of .rdp file.
+                Raw .rdp file.
             </summary>
         </member>
         <member name="T:RdRemoteAppsParser.Models.FolderModel">

--- a/RdRemoteAppsParserTests/RdWebClientTests.cs
+++ b/RdRemoteAppsParserTests/RdWebClientTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -50,10 +48,8 @@ namespace RdRemoteAppsParser.Tests
             var folderModel = client.GetAllRemoteElements().Result;
 
             var contsinsApps = folderModel.Apps.Any();
-            var allPngInRootAreValid = folderModel.Apps.All(app =>
-                Regex.IsMatch(app.PngPathUrl, @"^\/(.*?).png$", RegexOptions.Compiled | RegexOptions.Singleline));
-            var allRdpInRootAreValid = folderModel.Apps.All(app =>
-                Regex.IsMatch(app.RdpFileUrl, @"^\/(.*?).rdp$", RegexOptions.Compiled | RegexOptions.Singleline));
+            var allPngInRootAreValid = folderModel.Apps.All(app => app.PngFileRaw.Length > 8);
+            var allRdpInRootAreValid = folderModel.Apps.All(app => app.RdpFileRaw.Length > 8);
             var appsPathesAreValid = folderModel.Apps.All(app =>
                 Regex.IsMatch(app.Path, @"^\/\/[^\/]+$", RegexOptions.Compiled | RegexOptions.Singleline));
             var foldersPathesAreValid = folderModel.Subfolders.All(app =>


### PR DESCRIPTION
Since to download the icon and the .rdp file, you still need an authorized copy of the HttpClient, it was decided to upload the contents of the files immediately.